### PR TITLE
Add "-H" to grep when generating the list of VMs to start even if the…

### DIFF
--- a/rc.d/chyves
+++ b/rc.d/chyves
@@ -27,7 +27,7 @@ __chyves_start()
 	sleep 8 # Sleeping for network to come up.
 	local _previous_stdout_level="$( /usr/local/sbin/chyves list global | grep stdout_level | awk '{ print $2 }' )"
 	/usr/local/sbin/chyves global set stdout_level=0
-	local _guestlist="$( grep -E '^rcboot=' /chyves/*/guests/*/.config/.cfg | awk 'BEGIN { FS = "=" } ; $2 > "0" { print $1" "$2 }' | sort -Vrk2 | cut -d'/' -f5 | tr '\n' ',' | sed 's/,$//g' )"
+	local _guestlist="$( grep -H -E '^rcboot=' /chyves/*/guests/*/.config/.cfg | awk 'BEGIN { FS = "=" } ; $2 > "0" { print $1" "$2 }' | sort -Vrk2 | cut -d'/' -f5 | tr '\n' ',' | sed 's/,$//g' )"
 	echo "Starting chyves guests ($_guestlist)..."
 	/usr/local/sbin/chyves $_guestlist start
 	echo "Guests starting, resuming host boot."


### PR DESCRIPTION
the chyves startup script currently fails to generate a list of VMs with rcboot>0 if there is only one VM setup and it has rcboot > 0. The grep in the script fails, as with only one file matching the filename is not included in output. Adding -H to grep fixes that.